### PR TITLE
Fixes MAM_DIR env var and adds integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,6 @@ clean: ## Cleans the bin directory
 
 lint: ## Runs the Go Linter
 	golangci-lint run
+
+test: ## Runs go tests
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Program that handles dynamically setting the latest IP Address from your seedbox
 
 ## Configuration
 
-The `MAM_ID` is only required for the very first run. Subsequent runs will pull from the stored cookie, saved in the `$MAMUPDATE_DIR`.
+The `MAM_ID` is only required for the very first run. Subsequent runs will pull from the stored cookie, saved in the `$MAM_UPDATE_DIR`.
 
 ### Environment Variables
 
 | Variable      | Description                                                                                                                                               | Required | Default Value         |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------------- |
 | MAM_ID        | The MAM ID given to you after creating a new session. This only needs to be provided on the first run. Subsequent runs pull from the stored cookies file. | false    |                       |
-| MAMUPDATE_DIR | The base directory that config, data, and cache are stored.                                                                                               | false    | $HOME/.mamupdate      |
+| MAM_UPDATE_DIR | The base directory that config, data, and cache are stored.                                                                                               | false    | $HOME/.mamupdate      |
 | LOG_LEVEL     | Can be used to set the log level (debug, info, warn, error)                                                                                               | false    | info                  |
 | IP_URL        | Can be used to set the URL used to retrieve an IP address                                                                                                 | false    | https://api.ipify.org |
 
@@ -20,7 +20,7 @@ The `MAM_ID` is only required for the very first run. Subsequent runs will pull 
 | Flag     | Description                                                                                                                                                                 | Required | Default Value  |
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------- |
 | -mam-id  | The MAM ID given to you after creating a new session. This only needs to be provided on the first run. Subsequent runs pull from the stored cookies file. Overrides $MAM_ID | false    | $MAM_ID        |
-| -mam-dir | The base directory that config, data, and cache are stored. Overrides $MAMUPDATE_DIR                                                                                        | false    | $MAMUPDATE_DIR |
+| -mam-dir | The base directory that config, data, and cache are stored. Overrides $MAM_UPDATE_DIR                                                                                        | false    | $MAM_UPDATE_DIR |
 | -force   | Can be used to override the `last_run_time`                                                                                                                                 | false    | false          |
 | -level   | Can be used to set the log level (debug, info, warn, error). Overrides $LOG_LEVEL                                                                                           | false    | $LOG_LEVEL     |
 
@@ -100,7 +100,7 @@ Just like the above configuration, the `MAM_ID` is only needed for the first inv
 ```
 docker run \
 -e MAM_ID=<token> \
--e MAMUPDATE_DIR=/mam \
+-e MAM_UPDATE_DIR=/mam \
 -v /volume1/docker/mam/data:/mam \
 --user $(id -u):$(id -g) \
 --network container:gluetun \

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,170 @@
+package app
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gellen89/mam-update/internal/appdir"
+	"github.com/gellen89/mam-update/internal/mamupdater"
+)
+
+type App struct {
+	config  *mamupdater.Config
+	appdirs *appdir.AppDirs
+}
+
+func New(args []string) (*App, error) {
+	// Parse flags
+	flagCfg, err := getFlags(args)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse flags: %w", err)
+	}
+
+	// Initialize logger
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: getLogLevel(flagCfg),
+	}))
+
+	// Determine data directory
+	appDirs, err := getAppDirs(flagCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the configuration
+	config := &mamupdater.Config{
+		DataDir:     appDirs.Data,
+		CookiePath:  filepath.Join(appDirs.Data, "MAM.cookie"),
+		IpPath:      filepath.Join(appDirs.Data, "MAM.ip"),
+		LastRunPath: filepath.Join(appDirs.Data, "last_run_time"),
+		MamId:       getMamId(flagCfg),
+		Force:       flagCfg.Force,
+		IpUrl:       getIpUrl(),
+		Logger:      logger,
+	}
+
+	return &App{config: config, appdirs: appDirs}, nil
+}
+
+func (a *App) Run(ctx context.Context) error {
+	if err := a.appdirs.EnsureDirs(); err != nil {
+		return fmt.Errorf("failed to ensure directories: %w", err)
+	}
+
+	updater, err := mamupdater.NewMamUpdater(a.config)
+	if err != nil {
+		return fmt.Errorf("failed to create mam updater: %w", err)
+	}
+
+	if err := updater.Run(ctx); err != nil {
+		return fmt.Errorf("mam update failed: %w", err)
+	}
+	return nil
+}
+
+func getAppDirs(flagCfg *flagConfig) (*appdir.AppDirs, error) {
+	if flagCfg.ConfigDir != nil && *flagCfg.ConfigDir != "" {
+		return appdir.New(*flagCfg.ConfigDir), nil
+	}
+	appDirs, err := appdir.NewFromAppName(".mamupdate")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build app directories: %w", err)
+	}
+	return appDirs, nil
+}
+
+type flagConfig struct {
+	MamId     *string
+	ConfigDir *string
+	Force     bool
+	LogLevel  *string
+}
+
+func getFlags(args []string) (*flagConfig, error) {
+	var mamId string
+	flag.StringVar(&mamId, "mam-id", "", "Provide the mam-id used for the initial request.")
+	var mamDir string
+	flag.StringVar(&mamDir, "mam-dir", "", "Provide the directory where the config and data will be persisted.")
+	var force bool
+	flag.BoolVar(&force, "force", false, "Specify force to override the last run time.")
+	var loglevel string
+	flag.StringVar(&loglevel, "level", "", "Specify a log level (debug, info, warn, error) default: info.")
+
+	flag.CommandLine = flag.NewFlagSet("", flag.ExitOnError) // Clear default flag set
+	err := flag.CommandLine.Parse(args)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse flags: %w", err)
+	}
+
+	return &flagConfig{
+		MamId:     &mamId,
+		ConfigDir: &mamDir,
+		Force:     force,
+		LogLevel:  &loglevel,
+	}, nil
+}
+
+func getMamId(flagCfg *flagConfig) *string {
+	if flagCfg.MamId != nil && *flagCfg.MamId != "" {
+		return flagCfg.MamId
+	}
+	envMamId := os.Getenv("MAM_ID")
+	if envMamId != "" {
+		return &envMamId
+	}
+	return nil
+}
+
+func getMamDir(flagCfg *flagConfig) *string {
+	if flagCfg.ConfigDir != nil && *flagCfg.ConfigDir != "" {
+		return flagCfg.ConfigDir
+	}
+	envMamDir := os.Getenv("MAMUPDATE_DIR")
+	if envMamDir != "" {
+		return &envMamDir
+	}
+	return nil
+}
+
+func getLogLevel(flagCfg *flagConfig) slog.Level {
+	if flagCfg.LogLevel != nil && *flagCfg.LogLevel != "" {
+		return toSlogLevel(*flagCfg.LogLevel)
+	}
+	envlevel := os.Getenv("LOG_LEVEL")
+	if envlevel != "" {
+		return toSlogLevel(envlevel)
+	}
+	return slog.LevelInfo
+}
+
+func toSlogLevel(input string) slog.Level {
+	switch strings.ToLower(input) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+const (
+	defaultIpUrl = "https://api.ipify.org"
+)
+
+func getIpUrl() string {
+	envUrl := os.Getenv("IP_URL")
+	if envUrl == "" {
+		return defaultIpUrl
+	}
+	return envUrl
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -137,7 +137,7 @@ func getMamDir(flagCfg *flagConfig) *string {
 	if flagCfg.ConfigDir != nil && *flagCfg.ConfigDir != "" {
 		return flagCfg.ConfigDir
 	}
-	envMamDir := os.Getenv("MAMUPDATE_DIR")
+	envMamDir := os.Getenv("MAM_UPDATE_DIR")
 	if envMamDir != "" {
 		return &envMamDir
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,7 +24,6 @@ func Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("failed to initialize application: %w", err)
 	}
 
-	// Run the application
 	if err := application.Run(ctx); err != nil {
 		return fmt.Errorf("failed to run application: %w", err)
 	}
@@ -42,7 +41,7 @@ func New(args []string) (*App, error) {
 	}))
 
 	mamDir := getMamDir(flagCfg)
-	// Determine data directory
+
 	appDirs, err := getAppDirs(mamDir)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -2,159 +2,29 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
-	"strings"
+	"os/signal"
+	"syscall"
 
-	"github.com/gellen89/mam-update/internal/appdir"
-	"github.com/gellen89/mam-update/internal/mamupdater"
+	"github.com/gellen89/mam-update/internal/app"
 )
 
 func main() {
-	flagCfg, err := getFlags(os.Args[1:])
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	// Initialize the application
+	application, err := app.New(os.Args[1:])
 	if err != nil {
-		panic(err)
-	}
-
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: getLogLevel(flagCfg),
-	}))
-
-	mamId := getMamId(flagCfg)
-	mamDir := getMamDir(flagCfg)
-
-	var appdirs *appdir.AppDirs
-	if mamDir != nil && *mamDir != "" {
-		appdirs = appdir.New(*mamDir)
-	} else {
-		var err error
-		appdirs, err = appdir.NewFromAppName(".mamupdate")
-		if err != nil {
-			logger.Error("Failed to get app directories", "error", err)
-			os.Exit(1)
-		}
-	}
-	logger.Debug(fmt.Sprintf("using mam dir: %s", appdirs.Data))
-
-	if err := appdirs.EnsureDirs(); err != nil {
-		logger.Error("Failed to ensure directories exist", "error", err)
+		slog.Error(fmt.Sprintf("failed to initialize application: %v", err))
 		os.Exit(1)
 	}
 
-	config := &mamupdater.Config{
-		DataDir:     appdirs.Data,
-		CookiePath:  filepath.Join(appdirs.Data, "MAM.cookie"),
-		IpPath:      filepath.Join(appdirs.Data, "MAM.ip"),
-		LastRunPath: filepath.Join(appdirs.Data, "last_run_time"),
-		MamId:       mamId,
-		Force:       flagCfg.Force,
-		IpUrl:       getIpUrl(),
-		Logger:      logger,
-	}
-
-	updater, err := mamupdater.NewMamUpdater(config)
-	if err != nil {
-		logger.Error("Failed to create updater", "error", err)
+	// Run the application
+	if err := application.Run(ctx); err != nil {
+		slog.Error(fmt.Sprintf("failed to run application: %v", err))
 		os.Exit(1)
 	}
-	ctx := context.Background()
-	if err := updater.Run(ctx); err != nil {
-		logger.Error("Failed to run updater", "error", err)
-		os.Exit(1)
-	}
-	logger.Debug("run completed")
-}
-
-type flagConfig struct {
-	MamId     *string
-	ConfigDir *string
-	Force     bool
-	LogLevel  *string
-}
-
-func getFlags(args []string) (*flagConfig, error) {
-	var mamId string
-	flag.StringVar(&mamId, "mam-id", "", "Provide the mam-id used for the initial request.")
-	var mamDir string
-	flag.StringVar(&mamDir, "mam-dir", "", "Provide the directory where the config and data will be persisted.")
-	var force bool
-	flag.BoolVar(&force, "force", false, "Specify force to override the last run time.")
-	var loglevel string
-	flag.StringVar(&loglevel, "level", "", "Specify a log level (debug, info, warn, error) default: info.")
-
-	flag.CommandLine = flag.NewFlagSet("", flag.ExitOnError) // Clear default flag set
-	err := flag.CommandLine.Parse(args)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse flags: %w", err)
-	}
-
-	return &flagConfig{
-		MamId:     &mamId,
-		ConfigDir: &mamDir,
-		Force:     force,
-		LogLevel:  &loglevel,
-	}, nil
-}
-
-func getMamId(flagCfg *flagConfig) *string {
-	if flagCfg.MamId != nil && *flagCfg.MamId != "" {
-		return flagCfg.MamId
-	}
-	envMamId := os.Getenv("MAM_ID")
-	if envMamId != "" {
-		return &envMamId
-	}
-	return nil
-}
-
-func getMamDir(flagCfg *flagConfig) *string {
-	if flagCfg.ConfigDir != nil && *flagCfg.ConfigDir != "" {
-		return flagCfg.ConfigDir
-	}
-	envMamDir := os.Getenv("MAMUPDATE_DIR")
-	if envMamDir != "" {
-		return &envMamDir
-	}
-	return nil
-}
-
-func getLogLevel(flagCfg *flagConfig) slog.Level {
-	if flagCfg.LogLevel != nil && *flagCfg.LogLevel != "" {
-		return toSlogLevel(*flagCfg.LogLevel)
-	}
-	envlevel := os.Getenv("LOG_LEVEL")
-	if envlevel != "" {
-		return toSlogLevel(envlevel)
-	}
-	return slog.LevelInfo
-}
-
-func toSlogLevel(input string) slog.Level {
-	switch strings.ToLower(input) {
-	case "debug":
-		return slog.LevelDebug
-	case "info":
-		return slog.LevelInfo
-	case "warn":
-		return slog.LevelWarn
-	case "error":
-		return slog.LevelError
-	default:
-		return slog.LevelInfo
-	}
-}
-
-const (
-	defaultIpUrl = "https://api.ipify.org"
-)
-
-func getIpUrl() string {
-	envUrl := os.Getenv("IP_URL")
-	if envUrl == "" {
-		return defaultIpUrl
-	}
-	return envUrl
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -15,16 +13,8 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	// Initialize the application
-	application, err := app.New(os.Args[1:])
+	err := app.Run(ctx, os.Args[1:])
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to initialize application: %v", err))
-		os.Exit(1)
-	}
-
-	// Run the application
-	if err := application.Run(ctx); err != nil {
-		slog.Error(fmt.Sprintf("failed to run application: %v", err))
-		os.Exit(1)
+		panic(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -14,7 +14,10 @@ import (
 )
 
 func main() {
-	flagCfg := getFlags()
+	flagCfg, err := getFlags(os.Args[1:])
+	if err != nil {
+		panic(err)
+	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: getLogLevel(flagCfg),
@@ -72,7 +75,7 @@ type flagConfig struct {
 	LogLevel  *string
 }
 
-func getFlags() *flagConfig {
+func getFlags(args []string) (*flagConfig, error) {
 	var mamId string
 	flag.StringVar(&mamId, "mam-id", "", "Provide the mam-id used for the initial request.")
 	var mamDir string
@@ -82,14 +85,18 @@ func getFlags() *flagConfig {
 	var loglevel string
 	flag.StringVar(&loglevel, "level", "", "Specify a log level (debug, info, warn, error) default: info.")
 
-	flag.Parse()
+	flag.CommandLine = flag.NewFlagSet("", flag.ExitOnError) // Clear default flag set
+	err := flag.CommandLine.Parse(args)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse flags: %w", err)
+	}
 
 	return &flagConfig{
 		MamId:     &mamId,
 		ConfigDir: &mamDir,
 		Force:     force,
 		LogLevel:  &loglevel,
-	}
+	}, nil
 }
 
 func getMamId(flagCfg *flagConfig) *string {

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,7 @@ func TestApp_Run_Success(t *testing.T) {
 
 	baseDir := t.TempDir()
 
-	t.Setenv("MAMUPDATE_DIR", baseDir)
+	t.Setenv("MAM_UPDATE_DIR", baseDir)
 	t.Setenv("MAM_SEEDBOX_URL", fmt.Sprintf("%s/mam", srv.URL))
 	t.Setenv("IP_URL", fmt.Sprintf("%s/ip", srv.URL))
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,83 @@
+package main_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gellen89/mam-update/internal/app"
+)
+
+func TestApp_Run_Success(t *testing.T) {
+	srv := startHTTPServer(t, getMux())
+
+	baseDir := t.TempDir()
+
+	t.Setenv("MAMUPDATE_DIR", baseDir)
+	t.Setenv("MAM_SEEDBOX_URL", fmt.Sprintf("%s/mam", srv.URL))
+	t.Setenv("IP_URL", fmt.Sprintf("%s/ip", srv.URL))
+
+	args := []string{"-mam-id", "1234"}
+	err := app.Run(context.Background(), args)
+	if err != nil {
+		t.Fatalf("failed to run app: %v", err)
+	}
+
+	lastrunFile := fmt.Sprintf("%s/last_run_time", baseDir)
+	_, err = os.ReadFile(lastrunFile)
+	if err != nil {
+		t.Fatalf("last run time file does not exist: %v", err)
+	}
+
+	ipAddrFile := fmt.Sprintf("%s/MAM.ip", baseDir)
+	ipAddrBits, err := os.ReadFile(ipAddrFile)
+	if err != nil {
+		t.Fatalf("MAM.ip file does not exist: %v", err)
+	}
+
+	if testIpAddr != string(ipAddrBits) {
+		t.Fatal("ip address was not correct when written to file")
+	}
+
+	cookieFile := fmt.Sprintf("%s/MAM.cookie", baseDir)
+	_, err = os.ReadFile(cookieFile)
+	if err != nil {
+		t.Fatalf("MAM.cookie file does not exist: %v", err)
+	}
+}
+
+type dynamicSeedboxResponse struct {
+	Success bool   `json:"Success"`
+	Msg     string `json:"msg"`
+}
+
+const (
+	testIpAddr = "192.168.1.100"
+)
+
+func getMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ip", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, testIpAddr)
+	})
+	mux.HandleFunc("/mam", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		resp := dynamicSeedboxResponse{Success: true, Msg: "ok"}
+		bits, _ := json.Marshal(&resp)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(bits)
+	})
+	return mux
+}
+
+func startHTTPServer(tb testing.TB, h http.Handler) *httptest.Server {
+	tb.Helper()
+	srv := httptest.NewServer(h)
+	tb.Cleanup(srv.Close)
+	return srv
+}


### PR DESCRIPTION
Refactors main.go logic into a Cmd for better testing.

- Renamed MAMUPDATE_DIR to MAM_UPDATE_DIR
- Adds MAM_SEEDBOX_URL
- Updates root context to listen to Interrupt and SIGTERM signals for good cancelability. 